### PR TITLE
MAIN: Update SF writer in manifest of Snowpark Streamlit and Keboola Ecommerce template

### DIFF
--- a/keboola-ecommerce/v0/src/manifest.jsonnet
+++ b/keboola-ecommerce/v0/src/manifest.jsonnet
@@ -144,7 +144,7 @@
     },
     if InputIsAvailable("wr-snowflake-db-host") then
     {
-      componentId: "keboola.wr-snowflake-blob-storage",
+      componentId: SnowflakeWriterComponentId(),
       id: ConfigId("data-destination-out-ecommerce-snowflake"),
       path: "<common>/out-ecommerce-snowflake/v1/src/writer/keboola.wr-snowflake-blob-storage/data-destination-out-ecommerce-snowflake",
       rows: [

--- a/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/001-keboola-wr-snowflake-blob-storage-func-config-id-data-destination-out-ecommerce-snowflake/task.jsonnet
+++ b/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/001-keboola-wr-snowflake-blob-storage-func-config-id-data-destination-out-ecommerce-snowflake/task.jsonnet
@@ -1,9 +1,9 @@
 {
-  name: "keboola.wr-snowflake-blob-storage-" + ConfigId("data-destination-out-ecommerce-snowflake"),
+  name: "keboola.wr-snowflake-" + ConfigId("data-destination-out-ecommerce-snowflake"),
   enabled: true,
   task: {
     mode: "run",
-    configPath: "<common>/out-ecommerce-bigquery/v1/src/writer/keboola.wr-google-bigquery-v2/data-destination-out-ecommerce-bigquery",
+    configPath: "<common>/out-ecommerce-snowflake/v1/src/writer/keboola.wr-snowflake-blob-storage/data-destination-out-ecommerce-snowflake",
   },
   continueOnFailure: false,
 }

--- a/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/002-keboola-wr-google-bigquery-v2-func-config-id-data-destination-out-ecommerce-bigquery/task.jsonnet
+++ b/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/002-keboola-wr-google-bigquery-v2-func-config-id-data-destination-out-ecommerce-bigquery/task.jsonnet
@@ -3,7 +3,7 @@
   enabled: true,
   task: {
     mode: "run",
-    configPath: "<common>/out-ecommerce-snowflake/v1/src/writer/keboola.wr-snowflake-blob-storage/data-destination-out-ecommerce-snowflake",
+    configPath: "<common>/out-ecommerce-bigquery/v1/src/writer/keboola.wr-google-bigquery-v2/data-destination-out-ecommerce-bigquery",
   },
   continueOnFailure: false,
 }

--- a/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/kbcdir.jsonnet
+++ b/keboola-ecommerce/v0/src/other/keboola.orchestrator/flow-ecommerce-for-new-template/phases/004-step-4/kbcdir.jsonnet
@@ -1,3 +1,3 @@
 {
-  isIgnored: InputIsAvailable("google-sheet-id") == false && InputIsAvailable("wr-postgresql-db-hostname") == false,
+  isIgnored: InputIsAvailable("google-sheet-id") == false && InputIsAvailable("wr-postgresql-db-hostname") == false && InputIsAvailable("wr-snowflake-db-host") == false && InputIsAvailable("wr-google-bigquery-v2-service-account-private-key") == false,
 }

--- a/snowpark-streamlit/v0/src/manifest.jsonnet
+++ b/snowpark-streamlit/v0/src/manifest.jsonnet
@@ -74,7 +74,7 @@
       rows: [],
     },
     {
-      componentId: "keboola.wr-snowflake-blob-storage",
+      componentId: SnowflakeWriterComponentId(),
       id: ConfigId("create-snowflake-scheme"),
       path: "writer/keboola.wr-snowflake-blob-storage/create-snowflake-scheme",
       metadata: {


### PR DESCRIPTION
Two small changes in manifest.jsonnet:

from: componentId: "keboola.wr-snowflake-blob-storage",
to: componentId: SnowflakeWriterComponentId(),

Also found a bug that in flow I switched BQ writer with SF writer by accident + updated conditions in kbcdir.jsonnet in flow-phase4.